### PR TITLE
Use Services global variable

### DIFF
--- a/api/FPVS/implementation.js
+++ b/api/FPVS/implementation.js
@@ -13,7 +13,6 @@
   var { MailServices } = ChromeUtils.import(
     "resource:///modules/MailServices.jsm"
   );
-  var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
 
   let windowListener;
   const logEnabled = false;


### PR DESCRIPTION
Services.jsm is planned to be removed in Firefox 117 cycle in https://bugzilla.mozilla.org/show_bug.cgi?id=1780695 . Services global variable is available in WebExtensions experiments API global from version 88 https://bugzilla.mozilla.org/show_bug.cgi?id=1698158 , and experiments code doesn't have to import Services.jsm if the strict_min_version is 91.